### PR TITLE
fix chain pattern bug

### DIFF
--- a/lib/di.js
+++ b/lib/di.js
@@ -77,7 +77,7 @@ methods.concat('all').forEach(function(method) {
       };
     });
 
-    origin.apply(this, callbacks);
+    return origin.apply(this, callbacks);
   };
 });
 


### PR DESCRIPTION
to support route chain pattern

```
app.route('/examples')
.get(function(req, res, next){})
.post(function(req, res, next){});
```
