### PR TITLE
Naive implementation of nested factory dependencies

### DIFF
--- a/lib/di.js
+++ b/lib/di.js
@@ -21,59 +21,68 @@ express.Router.prototype.route = function(method, path) {
 
   callbacks = callbacks
     .map(function(fn) {
-      if (typeof fn !== 'function') return fn;
-
-      var parameters = utils.getParameters(fn);
-
-      if (!utils.needInject(parameters)) {
-        return fn;
-      }
-
-      return function(req, res, next) {
-        if (!req.__di_caches) {
-          req.__di_caches = {};
+      
+      return createWrapperFunction(fn);
+      
+      function createWrapperFunction(fn) {
+        
+        if (typeof fn !== 'function') return fn;
+  
+        var parameters = utils.getParameters(fn);
+  
+        if (!utils.needInject(parameters)) {
+          return fn;
         }
-        var self = this;
-        mapSeries(parameters, function(dependency, callback) {
-          if (dependency === 'req')  return callback(null, req);
-          if (dependency === 'res')  return callback(null, res);
-          if (dependency === 'next') return callback(null, next);
-
-          var currentApp = req.app,
-              factories,
-              factory;
-
-          while(currentApp) {
-            factories = currentApp.get(diFactoriesKey);
-            if (factories) {
-              if (factories[dependency]) {
-                factory = factories[dependency];
+        
+        return function(req, res, next) {
+          if (!req.__di_caches) {
+            req.__di_caches = {};
+          }
+          var self = this;
+          
+          mapSeries(parameters, function(dependency, callback) {
+            if (dependency === 'req')  return callback(null, req);
+            if (dependency === 'res')  return callback(null, res);
+            if (dependency === 'next') return callback(null, next);
+  
+            var currentApp = req.app,
+                factories,
+                factory;
+                
+            while(currentApp) {
+              factories = currentApp.get(diFactoriesKey);
+              if (factories) {
+                if (factories[dependency]) {
+                  factory = factories[dependency];
+                  break;
+                }
+                currentApp = currentApp.parent;
+              } else {
                 break;
               }
-              currentApp = currentApp.parent;
-            } else {
-              break;
             }
-          }
-          if (!factory) {
-            throw new Error('Unrecognized dependency: ' + dependency);
-          }
-
-          if (req.__di_caches[dependency]) {
-            callback(req.__di_caches[dependency][0], req.__di_caches[dependency][1]);
-          } else {
-            factory(req, res, function(err, result) {
-              req.__di_caches[dependency] = [err, result];
-              callback(err, result);
-            });
-          }
+            
+            if (!factory) {
+              throw new Error('Unrecognized dependency: ' + dependency);
+            }
+  
+            if (req.__di_caches[dependency]) {
+              callback(req.__di_caches[dependency][0], req.__di_caches[dependency][1]);
+            } else {
+              createWrapperFunction(factory)(req, res, function(err, result) {
+                req.__di_caches[dependency] = [err, result];
+                callback(err, result);
+              });
+            }
+            
         }, function(err, results) {
           if (err) {
             return next(err);
           }
           fn.apply(self, results);
         });
-      };
+        }
+      }
     });
 
   route.call(this, method, path, callbacks);


### PR DESCRIPTION
Hi,

This pull request is intended to be a strawman implementation of having factory dependencies. It creates a wrapper function for the factory functions lazily.

This implementation has the following obvious problems:
1. It's possible to create an infinite recursive loop with cyclic dependencies
2. It will not perform well - this implementation wires up dependencies lazily and doesn't cache them.

I would like to start a discussion on more preferable implementations to this.

Of course, if you're not interested say so and I'll run with my own fork. :)

The goal I'm trying to achieve is to have code like this:

``` javascript
var express = require('express');
require('express-di');

var app = express();

app.factory('foo', function(req, res, next) {
    next(null, 'foo');
});

app.factory('bar', function(req, res, next) {
    next(null, 'bar');
});

app.factory('foobar', function(foo, bar, req, res, next) {
    next(null, {foo: foo, bar: bar});
});

app.get('/', function(foobar, req, res) {
    res.json(foobar);
});

require('http').createServer(app).listen(process.env.PORT);
```
